### PR TITLE
Allow sending any object as a command

### DIFF
--- a/Cqrs.Autofac.Tests/TestHelpers/SecondTestCommand.cs
+++ b/Cqrs.Autofac.Tests/TestHelpers/SecondTestCommand.cs
@@ -1,6 +1,6 @@
 ﻿namespace Affecto.Patterns.Cqrs.Autofac.Tests.TestHelpers
 {
-    public class SecondTestCommand : ICommand
+    public class SecondTestCommand
     {
     }
 }

--- a/Cqrs.Autofac.Tests/TestHelpers/TestCommand.cs
+++ b/Cqrs.Autofac.Tests/TestHelpers/TestCommand.cs
@@ -1,6 +1,6 @@
 ﻿namespace Affecto.Patterns.Cqrs.Autofac.Tests.TestHelpers
 {
-    public class TestCommand : ICommand
+    public class TestCommand
     {
     }
 }

--- a/Cqrs.Tests/AsyncCommandBusTests.cs
+++ b/Cqrs.Tests/AsyncCommandBusTests.cs
@@ -39,7 +39,7 @@ namespace Affecto.Patterns.Cqrs.Tests
         {
             try
             {
-                sut.SendAsync(null).Wait();
+                sut.SendAsync<TestCommand>(null).Wait();
                 Assert.Fail();
             }
             catch (AggregateException e)

--- a/Cqrs.Tests/CommandBusTests.cs
+++ b/Cqrs.Tests/CommandBusTests.cs
@@ -38,7 +38,7 @@ namespace Affecto.Patterns.Cqrs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void EnvelopeCannotBeNull()
         {
-            sut.Send(null);
+            sut.Send<TestCommand>(null);
         }
 
         [TestMethod]

--- a/Cqrs.Tests/EnvelopeTests.cs
+++ b/Cqrs.Tests/EnvelopeTests.cs
@@ -43,7 +43,7 @@ namespace Affecto.Patterns.Cqrs.Tests
         [TestMethod]
         public void BodyIsSetFromFactory()
         {
-            Envelope<ICommand> sut = Envelope.Create(command);
+            Envelope<TestCommand> sut = Envelope.Create(command);
 
             Assert.AreSame(command, sut.Body);
         }
@@ -59,7 +59,7 @@ namespace Affecto.Patterns.Cqrs.Tests
         [TestMethod]
         public void CorrelationIdIsSetFromFactory()
         {
-            Envelope<ICommand> sut = Envelope.Create(command, CorrelationId);
+            Envelope<TestCommand> sut = Envelope.Create(command, CorrelationId);
 
             Assert.AreSame(CorrelationId, sut.CorrelationId);
         }

--- a/Cqrs.Tests/TestHelpers/TestCommand.cs
+++ b/Cqrs.Tests/TestHelpers/TestCommand.cs
@@ -1,6 +1,6 @@
 ﻿namespace Affecto.Patterns.Cqrs.Tests.TestHelpers
 {
-    public class TestCommand : ICommand
+    public class TestCommand
     {
     }
 }

--- a/Cqrs/AsyncCommandBus.cs
+++ b/Cqrs/AsyncCommandBus.cs
@@ -28,7 +28,8 @@ namespace Affecto.Patterns.Cqrs
         /// Sends command to the bus for execution.
         /// </summary>
         /// <param name="command">Command wrapped in an envelope.</param>
-        public virtual async Task SendAsync(Envelope<ICommand> command)
+        /// <typeparam name="TCommand">Command type.</typeparam>
+        public virtual async Task SendAsync<TCommand>(Envelope<TCommand> command) where TCommand : class
         {
             if (command == null)
             {
@@ -38,7 +39,7 @@ namespace Affecto.Patterns.Cqrs
             await ExecuteAsync((dynamic) command.Body);
         }
 
-        private async Task ExecuteAsync<TCommand>(TCommand commandBody) where TCommand : class, ICommand
+        private async Task ExecuteAsync<TCommand>(TCommand commandBody) where TCommand : class
         {
             IAsyncCommandHandler<TCommand> handler = commandHandlerResolver.ResolveCommandHandler<IAsyncCommandHandler<TCommand>>();
             await handler.ExecuteAsync(commandBody);

--- a/Cqrs/CommandBus.cs
+++ b/Cqrs/CommandBus.cs
@@ -27,7 +27,8 @@ namespace Affecto.Patterns.Cqrs
         /// Sends command to the bus for execution.
         /// </summary>
         /// <param name="command">Command wrapped in an envelope.</param>
-        public virtual void Send(Envelope<ICommand> command)
+        /// /// <typeparam name="TCommand">Command type.</typeparam>
+        public virtual void Send<TCommand>(Envelope<TCommand> command) where TCommand : class
         {
             if (command == null)
             {
@@ -37,7 +38,7 @@ namespace Affecto.Patterns.Cqrs
             Execute((dynamic) command.Body);
         }
 
-        private void Execute<TCommand>(TCommand commandBody) where TCommand : class, ICommand
+        private void Execute<TCommand>(TCommand commandBody) where TCommand : class
         {
             ICommandHandler<TCommand> handler = commandHandlerResolver.ResolveCommandHandler<ICommandHandler<TCommand>>();
             handler.Execute(commandBody);

--- a/Cqrs/Cqrs.csproj
+++ b/Cqrs/Cqrs.csproj
@@ -49,7 +49,6 @@
     <Compile Include="CommandHandlerResolver.cs" />
     <Compile Include="CommandHandlerResolverBase.cs" />
     <Compile Include="Envelope.cs" />
-    <Compile Include="ICommand.cs" />
     <Compile Include="IAsyncCommandBus.cs" />
     <Compile Include="ICommandBus.cs" />
     <Compile Include="IAsyncCommandHandler.cs" />

--- a/Cqrs/Cqrs.nuspec
+++ b/Cqrs/Cqrs.nuspec
@@ -7,6 +7,6 @@
     <description>$description$</description>
     <projectUrl>https://github.com/affecto/dotnet-Patterns.Cqrs</projectUrl>
     <tags>affecto pattern patterns cqrs command query responsibility segregation cqs separation</tags>
-    <releaseNotes>Added asynchronous versions of the command bus and command handler. Raised to .NET 4.5.2.</releaseNotes>
+    <releaseNotes>Removed ICommand interface. This allows sending any object as a command to the bus.</releaseNotes>
   </metadata>
 </package>

--- a/Cqrs/Envelope.cs
+++ b/Cqrs/Envelope.cs
@@ -12,16 +12,18 @@ namespace Affecto.Patterns.Cqrs
         /// </summary>
         /// <param name="body">Command body.</param>
         /// <param name="correlationId">Correlation id for tracking the command execution.</param>
-        public static Envelope<ICommand> Create<TCommand>(TCommand body, string correlationId = null) where TCommand : class, ICommand
+        /// <typeparam name="TCommand">Command type.</typeparam>
+        public static Envelope<TCommand> Create<TCommand>(TCommand body, string correlationId = null) where TCommand : class
         {
-            return new Envelope<ICommand>(body, correlationId);
+            return new Envelope<TCommand>(body, correlationId);
         }
     }
 
     /// <summary>
     /// Provides the envelope for a command that will be sent to a bus.
     /// </summary>
-    public class Envelope<TCommand> : Envelope where TCommand : class, ICommand
+    /// <typeparam name="TCommand">Command type.</typeparam>
+    public class Envelope<TCommand> : Envelope where TCommand : class
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Envelope{T}"/> class.

--- a/Cqrs/IAsyncCommandBus.cs
+++ b/Cqrs/IAsyncCommandBus.cs
@@ -11,6 +11,7 @@ namespace Affecto.Patterns.Cqrs
         /// Sends command to the bus for execution.
         /// </summary>
         /// <param name="command">Command wrapped in an envelope.</param>
-        Task SendAsync(Envelope<ICommand> command);
+        /// <typeparam name="TCommand">Command type.</typeparam>
+        Task SendAsync<TCommand>(Envelope<TCommand> command) where TCommand : class;
     }
 }

--- a/Cqrs/IAsyncCommandHandler.cs
+++ b/Cqrs/IAsyncCommandHandler.cs
@@ -6,7 +6,7 @@ namespace Affecto.Patterns.Cqrs
     /// Handler for asynchronously executing commands that were sent to a bus.
     /// </summary>
     /// <typeparam name="TCommand">Command type.</typeparam>
-    public interface IAsyncCommandHandler<in TCommand> : ICommandHandler where TCommand : class, ICommand
+    public interface IAsyncCommandHandler<in TCommand> : ICommandHandler where TCommand : class
     {
         /// <summary>
         /// Asynchronously executes a command that was sent to a bus.

--- a/Cqrs/ICommand.cs
+++ b/Cqrs/ICommand.cs
@@ -1,9 +1,0 @@
-namespace Affecto.Patterns.Cqrs
-{
-    /// <summary>
-    /// A command that will be sent to a bus.
-    /// </summary>
-    public interface ICommand
-    {
-    }
-}

--- a/Cqrs/ICommandBus.cs
+++ b/Cqrs/ICommandBus.cs
@@ -9,6 +9,7 @@
         /// Sends command to the bus for execution.
         /// </summary>
         /// <param name="command">Command wrapped in an envelope.</param>
-        void Send(Envelope<ICommand> command);
+        /// <typeparam name="TCommand">Command type.</typeparam>
+        void Send<TCommand>(Envelope<TCommand> command) where TCommand : class;
     }
 }

--- a/Cqrs/ICommandHandler.cs
+++ b/Cqrs/ICommandHandler.cs
@@ -11,7 +11,7 @@ namespace Affecto.Patterns.Cqrs
     /// Handler for executing commands that were sent to a bus.
     /// </summary>
     /// <typeparam name="TCommand">Command type.</typeparam>
-    public interface ICommandHandler<in TCommand> : ICommandHandler where TCommand : class, ICommand
+    public interface ICommandHandler<in TCommand> : ICommandHandler where TCommand : class
     {
         /// <summary>
         /// Executes a command that was sent to a bus.

--- a/Cqrs/Properties/AssemblyInfo.cs
+++ b/Cqrs/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@
 [assembly: AssemblyDescription("Interfaces and base implementation for the Command Query Responsibility Segregation (CQRS) pattern.")]
 [assembly: AssemblyCompany("Affecto")]
 
-[assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]
 
 // This version is used by NuGet:
-[assembly: AssemblyInformationalVersion("3.0.0")]
+[assembly: AssemblyInformationalVersion("4.0.0")]

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
   * Autofac implementation for the command handler resolver defined in Affecto.Patterns.Cqrs NuGet.
   * NuGet: https://www.nuget.org/packages/Affecto.Patterns.Cqrs.Autofac
 
-## Build status
+### Build status
 
-| Target | Build |
-| -----------------------|------------------|
-| Project | [![Build status](https://ci.appveyor.com/api/projects/status/62shi9ba6v53ln7n?svg=true)](https://ci.appveyor.com/project/affecto/dotnet-patterns-cqrs) |
-| Master branch | [![Build status](https://ci.appveyor.com/api/projects/status/62shi9ba6v53ln7n/branch/master?svg=true)](https://ci.appveyor.com/project/affecto/dotnet-patterns-cqrs/branch/master) |
-| Development branch | [![Build status](https://ci.appveyor.com/api/projects/status/62shi9ba6v53ln7n/branch/development?svg=true)](https://ci.appveyor.com/project/affecto/dotnet-patterns-cqrs/branch/development) |
+[![Build status](https://ci.appveyor.com/api/projects/status/62shi9ba6v53ln7n?svg=true)](https://ci.appveyor.com/project/affecto/dotnet-patterns-cqrs)


### PR DESCRIPTION
Removed ICommand interface. This allows sending any object as a command to the bus.
